### PR TITLE
Added support for selecting javax.swing.JList items by text.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply from: 'https://repository-javafx-gradle-plugin.forge.cloudbees.com/snapsho
 defaultTasks 'clean', 'jar', 'test'
 
 group = 'com.athaydes.automaton'
-version = "1.2.1"
+version = "1.2.2"
 description = 'Automaton is a tool for easily automating GUI tests in JavaFX and Swing'
 
 sourceCompatibility = 1.7

--- a/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
+++ b/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
@@ -50,6 +50,24 @@ class SwingUtil {
         )
     }
 
+    protected static Component listItem2FakeComponent( JList list, int index ) {
+        def item = list.model.getElementAt( index )
+        def listComp = list.cellRenderer.getListCellRendererComponent( list, item, index, false, false )
+		def listItemText
+		if ( listComp instanceof JLabel ) {
+			// the default renderer will return JLabel components - get text from that
+			listItemText = listComp.text
+		} else {
+			// if the default renderer was not used, attempt to get the text from the item's toString
+			listItemText = item.toString()
+		}
+        new FakeComponent( listItemText,
+                { list.locationOnScreen },
+                {
+					list.ui.getCellBounds(list, index, index)
+                } )
+    }
+
     /**
 	 * Navigates the tree under the given root, calling the given action for each Component.
 	 * To stop navigating, action may return true

--- a/src/main/groovy/com/athaydes/automaton/selector/SwingerSelector.groovy
+++ b/src/main/groovy/com/athaydes/automaton/selector/SwingerSelector.groovy
@@ -63,6 +63,13 @@ abstract class SwingerSelectorBase extends Closure<List<Component>>
                             stop = visitor( tabComp )
                         }
                         break
+                    case JList:
+                        def jlist = comp as JList
+                        for ( index in 0..<jlist.model.size ) {
+                            def listComp = listItem2FakeComponent( jlist, index )
+                            stop = visitor( listComp )
+                        }
+                        break
 				}
 			return stop
 		}

--- a/src/test/groovy/com/athaydes/automaton/samples/JListSample.groovy
+++ b/src/test/groovy/com/athaydes/automaton/samples/JListSample.groovy
@@ -1,0 +1,50 @@
+package com.athaydes.automaton.samples
+
+import com.athaydes.automaton.Speed
+import com.athaydes.automaton.Swinger
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+import javax.swing.*
+import java.awt.*
+
+class JListSample {
+
+    JFrame frame
+
+    @Before
+    void before( ) {
+        frame = new JFrame( 'JList Test' )
+        frame.layout = new FlowLayout( )
+
+        String[] listItems = [ 'green', 'red', 'orange', 'dark blue', 'yellow', 'black', 'mauve', 'brown', 'purple' ]
+        JList list = new JList( listItems )
+        list.layoutOrientation = JList.VERTICAL_WRAP
+        list.visibleRowCount = 3
+
+        frame.add( new JScrollPane( list ) )
+        frame.pack( )
+
+        frame.visible = true
+    }
+
+    @After
+    void after( ) {
+        frame?.dispose()
+    }
+
+    @Test
+    void "List items on a multi-column JList can be clicked on using a text selector" () {
+        // Use the swinger to click on JList cells in each column
+        Swinger swing = Swinger.forSwingWindow( )
+
+        swing.clickOn( 'text:black', Speed.VERY_FAST ).pause( 250 )
+        swing.clickOn( 'text:green', Speed.VERY_FAST ).pause( 250 )
+        swing.clickOn( 'text:dark blue', Speed.VERY_FAST ).pause( 250 )
+        swing.clickOn( 'text:brown', Speed.VERY_FAST ).pause( 250 )
+        swing.clickOn( 'text:red', Speed.VERY_FAST ).pause( 250 )
+        swing.clickOn( 'text:purple', Speed.VERY_FAST )
+    }
+
+}


### PR DESCRIPTION
I added support for finding JList items by their text. It will work if the default cell renderer is used. It has been tested with both single and multi-column lists.

I added a sample (src/test/groovy/com/athaydes/automaton/samples/JListSample.groovy) where JList items in a list with three columns are being clicked on using a text selector.