### PR TITLE
Extract table cell value from cell renderer rather than model (Fixes #32)

### DIFF
--- a/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
+++ b/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
@@ -137,10 +137,21 @@ class SwingUtil {
 		}
 		for ( row in rows ) {
 			for ( col in cols ) {
-				if ( action( table.model.getValueAt( row, col ), row, col ) ) return true
+				if ( action( getRenderedTableValue(table, row, col ), row, col ) ) return true
 			}
 		}
 		return false
+	}
+
+	private static Object getRenderedTableValue(JTable table, row, col) {
+		def value = table.model.getValueAt(row, col)
+		def rendererComp = table.getCellRenderer(row, col)
+				.getTableCellRendererComponent(table, value, false, false, row, col)
+		if (rendererComp instanceof JLabel) {
+			(rendererComp as JLabel).getText()
+		} else {
+			return value
+		}
 	}
 
 	/**

--- a/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
+++ b/src/main/groovy/com/athaydes/automaton/SwingUtil.groovy
@@ -143,15 +143,20 @@ class SwingUtil {
 		return false
 	}
 
-	private static Object getRenderedTableValue(JTable table, row, col) {
+	/**
+	 * Returns the text as rendered by the table cell's renderer component, if the renderer component
+	 * has a getText() method. Returns the model value at the cell's position otherwise.
+	 * @param table in question
+	 * @param row of the value to get
+	 * @param col of the value to get
+	 * @return The rendered value or the model value if the renderer doesn't have a getText() method
+	 */
+	private static getRenderedTableValue(JTable table, int row, int col) {
 		def value = table.model.getValueAt(row, col)
 		def rendererComp = table.getCellRenderer(row, col)
 				.getTableCellRendererComponent(table, value, false, false, row, col)
-		if (rendererComp instanceof JLabel) {
-			(rendererComp as JLabel).getText()
-		} else {
-			return value
-		}
+		def text = callMethodIfExists(rendererComp, 'getText')
+		return text ?: value
 	}
 
 	/**

--- a/src/test/groovy/com/athaydes/automaton/SwingBaseForTests.groovy
+++ b/src/test/groovy/com/athaydes/automaton/SwingBaseForTests.groovy
@@ -4,11 +4,13 @@ import com.athaydes.automaton.mixins.SwingTestHelper
 import com.athaydes.automaton.mixins.TimeAware
 import com.athaydes.automaton.selector.SimpleSwingerSelector
 import groovy.swing.SwingBuilder
+import javafx.beans.property.SimpleStringProperty
 import javafx.scene.layout.VBox
 import org.junit.After
 import org.junit.Test
 
 import javax.swing.*
+import javax.swing.table.DefaultTableCellRenderer
 import java.awt.*
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
@@ -309,6 +311,37 @@ abstract class SwingDriverWithSelectorsTest extends SimpleSwingDriverTest {
 		assert jTable.model.getValueAt( 1, 0 ) == 'row 2 col 1'
 		assert jTable.model.getValueAt( 1, 1 ) == 'row 2 col 2'
 
+	}
+
+	@Test
+	void testMoveTo_TableCell_CustomRenderer() {
+		def tModel = [
+				[ firstCol: new SimpleStringProperty('1 - 1'), secCol: new SimpleStringProperty('1 - 2') ],
+		]
+		def cellRenderer = new DefaultTableCellRenderer(){
+			@Override
+			protected void setValue(Object value) {
+				setText(((SimpleStringProperty) value).getValue())
+			}
+		}
+		JTable jTable = null
+		new SwingBuilder().edt {
+			jFrame = frame( title: 'Frame', size: [ 300, 200 ] as Dimension,
+					location: defaultLocation, show: true ) {
+				scrollPane {
+					jTable = table {
+						tableModel( list: tModel ) {
+							propertyColumn( header: 'Col 1', propertyName: 'firstCol', type: SimpleStringProperty.class, cellRenderer: cellRenderer )
+							propertyColumn( header: 'Col 2', propertyName: 'secCol', type: SimpleStringProperty.class, cellRenderer: cellRenderer )
+						}
+					}
+				}
+			}
+		}
+		waitForJFrameToShowUp()
+
+		assert withDriver().getAll( 'text:1 - 1' ).size() == 1
+		assert withDriver().getAll( 'text:1 - 2' ).size() == 1
 	}
 
 	@Test

--- a/src/test/groovy/com/athaydes/automaton/SwingBaseForTests.groovy
+++ b/src/test/groovy/com/athaydes/automaton/SwingBaseForTests.groovy
@@ -321,7 +321,7 @@ abstract class SwingDriverWithSelectorsTest extends SimpleSwingDriverTest {
 		def cellRenderer = new DefaultTableCellRenderer(){
 			@Override
 			protected void setValue(Object value) {
-				setText(((SimpleStringProperty) value).getValue())
+				setText(value.value)
 			}
 		}
 		JTable jTable = null


### PR DESCRIPTION
Suggested fix incl. test for https://github.com/renatoathaydes/Automaton/issues/32

It reads the cell's value from the renderer component, if it is a JLabel (as is the case in the DefaultTableCellRenderer). If the renderer component isn't a JLabel it returns the model value itself as previously.

This may break existing tests if they rely on the difference between model value and rendered value. But I can't think of a reason why you'd want that other than to work around the issue itself.